### PR TITLE
Change unity version to 2018

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "com.linqtogameobject",
   "displayName": "LINQ To GameObject For Unity",
   "version": "0.5.1",
-  "unity": "2019.4",
+  "unity": "2018",
   "description": "LINQ to GameObject is GameObject extensions for Unity that allows traverse hierarchy and append GameObject. The design aims both to get the power of LINQ and performance of iteration.",
   "keywords": [
     "unity",


### PR DESCRIPTION
The original library hasn't change since 2017, hence minimal required Unity version can be lower than 2019.4 😺 